### PR TITLE
Fix tcp resend with parsing packets

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -1,9 +1,11 @@
 {
     "LOCAL_HOST": "localhost",
     "LAN_HOST": "192.168.1.15",
+    "CONNECTION_CHECK_HOST": "192.168.1.16",
     "PI_ADDRESS": "192.168.1.17",
     "X_AXIS_CAP": 18000,
     "SERVER_PORT": 4002,
     "CAR_PORT": 4003,
-    "TEST_PORT": 4004
+    "TEST_PORT": 4004,
+    "CONNECTION_CHECK_PORT": 4005
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engineering-data-distributor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "engineering-data-distributor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-data-distributor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Server to distribute incoming packets from Solar Car 1 to engineering dashboard instances.",
   "main": "src/server.js",
   "repository": {

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -249,6 +249,44 @@ setupVPSInterface();
 
 
 //----------------------------------------------------- TCP ----------------------------------------------------------
+// Open port CONSTANTS.CONNECTION_CHECK_PORT on CONSTANTS.CONNECTION_CHECK_HOST for checking the status of the TCP
+// connection to the solar car
+const pingPort = net.createServer((socket) => {
+  function exit() {
+    if(!socket.destroyed) {
+      socket.destroy();
+    }
+  }
+
+  // Error, connection closed, and connection ended listeners
+  socket.on("error", (error) => {
+    exit();
+  });
+
+  socket.on("close", (close) => {
+    exit();
+  });
+
+  socket.on("end", () => {
+    exit();
+  });
+});
+
+pingPort.on('error', (err) => {
+  readline.pause();
+  console.error(`\nSolar car connection checking server error: ${err}`);
+  readline.prompt(true);
+});
+
+// Start listening for incoming connections from the solar car
+pingPort.listen(CONSTANTS.CONNECTION_CHECK_PORT, CONSTANTS.CONNECTION_CHECK_HOST, () => {
+  readline.pause();
+  console.log('\nSolar car connection checking server listening on ' +
+              `${CONSTANTS.CONNECTION_CHECK_HOST}:${CONSTANTS.CONNECTION_CHECK_PORT}`);
+  readline.prompt(true);
+});
+
+
 /**
  * Creates a connection with the TCP server at port CONSTANTS.CAR_PORT and address INCOMING_DATA_ADDRESS. Then, sets
  * listeners for connect, data, close, and error events. In the event of an error, the client will attempt to re-open


### PR DESCRIPTION
See #2. This includes changes for parsing packets with headers and footers, which was deemed unnecessary for the initial TCP resending fix.